### PR TITLE
ci: Use GITHUB_OUTPUT envvar instead of set-output command

### DIFF
--- a/.github/actions/go-dist-info/action.yml
+++ b/.github/actions/go-dist-info/action.yml
@@ -72,7 +72,7 @@ runs:
           GO_MAJOR_VERSION=$(echo "${GO_VERSION}" | sed 's/^go\([0-9][0-9]*\).*$/\1/')
           GO_VERSION="go${GO_MAJOR_VERSION}.${GO_MINOR_VERSION}"
         fi
-        echo "go-dist-version=$(echo $GO_VERSION)" >> $GITHUB_OUTPUT
+        echo "go-dist-version=$(echo $GO_VERSION)" >> "$GITHUB_OUTPUT"
     - id: go-dist-exists
       shell: bash
       run: |
@@ -84,4 +84,4 @@ runs:
         else
           echo "No directory found at ${GO_DIST_DIR_PATH}"
         fi
-        echo "go-dist-exists=$GO_DIST_EXISTS" >> $GITHUB_OUTPUT
+        echo "go-dist-exists=$GO_DIST_EXISTS" >> "$GITHUB_OUTPUT"

--- a/.github/actions/go-dist-info/action.yml
+++ b/.github/actions/go-dist-info/action.yml
@@ -72,7 +72,7 @@ runs:
           GO_MAJOR_VERSION=$(echo "${GO_VERSION}" | sed 's/^go\([0-9][0-9]*\).*$/\1/')
           GO_VERSION="go${GO_MAJOR_VERSION}.${GO_MINOR_VERSION}"
         fi
-        echo "::set-output name=go-dist-version::$(echo $GO_VERSION)"
+        echo "go-dist-version=$(echo $GO_VERSION)" >> $GITHUB_OUTPUT
     - id: go-dist-exists
       shell: bash
       run: |
@@ -84,4 +84,4 @@ runs:
         else
           echo "No directory found at ${GO_DIST_DIR_PATH}"
         fi
-        echo "::set-output name=go-dist-exists::$GO_DIST_EXISTS"
+        echo "go-dist-exists=$GO_DIST_EXISTS" >> $GITHUB_OUTPUT

--- a/.github/workflows/publish-godel-artifacts.yml
+++ b/.github/workflows/publish-godel-artifacts.yml
@@ -14,7 +14,7 @@ jobs:
       # START Go dist setup
       #####################
       - id: set-gopath
-        run: echo "GOPATH=$(go env GOPATH)" >> $GITHUB_OUTPUT
+        run: echo "GOPATH=$(go env GOPATH)" >> "$GITHUB_OUTPUT"
       - id: go-dist-info
         uses: ./.github/actions/go-dist-info
         with:

--- a/.github/workflows/publish-godel-artifacts.yml
+++ b/.github/workflows/publish-godel-artifacts.yml
@@ -14,7 +14,7 @@ jobs:
       # START Go dist setup
       #####################
       - id: set-gopath
-        run: echo "::set-output name=GOPATH::$(go env GOPATH)"
+        run: echo "GOPATH=$(go env GOPATH)" >> $GITHUB_OUTPUT
       - id: go-dist-info
         uses: ./.github/actions/go-dist-info
         with:


### PR DESCRIPTION
`save-state` and `set-output` commands used in GitHub Actions are deprecated and [GitHub recommends using environment files](https://github.blog/changelog/2023-07-24-github-actions-update-on-save-state-and-set-output-commands/).

This PR updates the usage of `set-output` to `$GITHUB_OUTPUT`

Instructions for envvar usage from GitHub docs:

https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-output-parameter


